### PR TITLE
CI: add initial CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: Base CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+    - uses: actions/checkout@v5
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install -U mypy ruff pandas-stubs "numpy>=1.26.3,<=2.1.3" matplotlib xgboost pandas scikit-learn openpyxl jinja2 python-ternary pytest shap interpret types-tqdm types-Pillow scikit-image lightgbm lime opencv-python-headless==4.10.0.84 pytest-cov
+    - name: lint
+      run: |
+        mypy .
+        ruff check .
+    - name: unit_tests
+      run: |
+        python -m pip install -v .
+        cd /tmp && python -m pytest --pyargs neat_ml --cov=neat_ml --cov-report=term-missing


### PR DESCRIPTION
* This adds linting and unit testing based on the in-house GitLab CI we've been using at
https://lisdi-git.lanl.gov/ldrd_dr_neat/ldrd_neat_ml. I've excluded the "functional test" we were previously using in-house because it times out after running for an hour, and is not really useful at this time.

* This CI configuration runs with more Python versions and platforms (MacOS and Linux) compared to the in-house CI config, so is a bit more thorough in that sense.