### PR TITLE
MAINT: add dependencies to pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,11 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: install and lint
       run: |
-        python -m pip install -U mypy ruff pandas-stubs "numpy>=1.26.3,<=2.1.3" matplotlib xgboost pandas scikit-learn openpyxl jinja2 python-ternary pytest shap interpret types-tqdm types-Pillow scikit-image lightgbm lime opencv-python-headless==4.10.0.84 pytest-cov
-    - name: lint
+        python -m pip install -v ".[dev]"
+        mypy neat_ml
+        ruff check neat_ml
+    - name: test
       run: |
-        mypy .
-        ruff check .
-    - name: unit_tests
-      run: |
-        python -m pip install -v .
         cd /tmp && python -m pytest --pyargs neat_ml --cov=neat_ml --cov-report=term-missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,13 @@ dependencies = [
     'opencv-python-headless==4.10.0.84'
 ]
 [project.optional-dependencies]
-dev = ['mypy', 'ruff', 'pandas-stubs', 'pytest', 'types-tqdm', 'types-Pillow']
+dev = ['mypy',
+       'ruff',
+       'pandas-stubs',
+       'pytest',
+       'pytest-xdist',
+       'pytest-cov',
+       'types-tqdm',
+       'types-Pillow']
 [tool.setuptools.package-data]
 "neat_ml.data" = ["*.xlsx"]


### PR DESCRIPTION
This MR adds the dependencies listed in `.gitlab-ci.yml` to `pyproject.toml` along with `optional-dependencies` for improved end-user ease of installation. 

from `.gitlab-ci.yml`, these dependencies are installed with:

```
python -m pip install -U mypy ruff pandas-stubs "numpy>=1.26.3,<=2.1.3" matplotlib xgboost pandas scikit-learn openpyxl jinja2 python-ternary pytest shap interpret types-tqdm types-Pillow scikit-image lightgbm lime opencv-python-headless==4.10.0.84
```

installation of the project using `python -m pip install -v ".[dev]"` allows all tests to pass with `python -m pytest`