### PR TITLE
BLD: pin scipy to `1.16.3`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,10 @@ dependencies = [
     'lightgbm',
     'lime',
     'opencv-python-headless==4.10.0.84',
-    # TODO: bump scipy version to ``==1.17.0``
-    # once legacy code has been purged from 
-    # repo as described in issue #18. Currently
-    # some tests related to `lime` feature importance
-    # are failing because of dependency issue.
+    # pinned due to bug in `scipy==1.17.0` causing
+    # NaN propagation through LIME explainer. See:
+    # https://github.com/scipy/scipy/issues/24355
+    # TODO: unpin when upstream issue is resolved
     'scipy<=1.16.3',
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
This PR pins `scipy<=1.16.3` dependency to `pyproject.toml` to avoid errors in the test-suite related to the outputs of `lime` values. Specifically, running the test-suite with `scipy==1.17.0` causes `test_build_lime_data` to fail with the following error for all four parametrized cases:

<details><summary>traceback:</summary>

```pytest
build LIME feature importance array:   0%|          | 0/4 [00:00<?, ?it/s]
______________________________________________________________________________________________________________________________ test_build_lime_row_selection _______________________________________________________________________________________________________________________________

    def test_build_lime_row_selection():
        # regression test for:
        # https://gitlab.lanl.gov/treddy/ldrd_neat_ml/-/merge_requests/36#note_279748
        data = np.eye(3, k=1)
        y = np.asarray([1, 1, 0])
        X = pd.DataFrame(data=data, columns=["1", "2", "3"])
        rf = RandomForestClassifier(random_state=0)
        rf.fit(X, y)
>       lime_actual = lib.build_lime_data(X=X, model=rf)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

neat_ml/tests/test_lib.py:162: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/joblib/memory.py:607: in __call__
    return self._cached_call(args, kwargs, shelving=False)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/joblib/memory.py:562: in _cached_call
    return self._call(call_id, args, kwargs, shelving)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/joblib/memory.py:832: in _call
    output = self.func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
neat_ml/lib.py:792: in build_lime_data
    exp = explainer_lime.explain_instance(X.to_numpy()[index],
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/lime/lime_tabular.py:452: in explain_instance
    ret_exp.score, ret_exp.local_pred) = self.base.explain_instance_with_data(
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/lime/lime_base.py:183: in explain_instance_with_data
    used_features = self.feature_selection(neighborhood_data,
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/lime/lime_base.py:134: in feature_selection
    return self.feature_selection(data, labels, weights,
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/lime/lime_base.py:76: in feature_selection
    return self.forward_selection(data, labels, weights, num_features)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/lime/lime_base.py:61: in forward_selection
    score = clf.score(data[:, used_features + [feature]],
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/sklearn/base.py:639: in score
    return r2_score(y, y_pred, sample_weight=sample_weight)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/sklearn/utils/_param_validation.py:218: in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/sklearn/metrics/_regression.py:1276: in r2_score
    _check_reg_targets_with_floating_dtype(
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/sklearn/metrics/_regression.py:209: in _check_reg_targets_with_floating_dtype
    y_type, y_true, y_pred, sample_weight, multioutput = _check_reg_targets(
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/sklearn/metrics/_regression.py:116: in _check_reg_targets
    y_pred = check_array(y_pred, ensure_2d=False, dtype=dtype)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/sklearn/utils/validation.py:1105: in check_array
    _assert_all_finite(
/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/sklearn/utils/validation.py:120: in _assert_all_finite
    _assert_all_finite_element_wise(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

X = array([nan, nan, nan, ..., nan, nan, nan])

    def _assert_all_finite_element_wise(
        X, *, xp, allow_nan, msg_dtype=None, estimator_name=None, input_name=""
    ):
        # Cython implementation doesn't support FP16 or complex numbers
        use_cython = (
            xp is np and X.data.contiguous and X.dtype.type in {np.float32, np.float64}
        )
        if use_cython:
            out = cy_isfinite(X.reshape(-1), allow_nan=allow_nan)
            has_nan_error = False if allow_nan else out == FiniteStatus.has_nan
            has_inf = out == FiniteStatus.has_infinite
        else:
            has_inf = xp.any(xp.isinf(X))
            has_nan_error = False if allow_nan else xp.any(xp.isnan(X))
        if has_inf or has_nan_error:
            if has_nan_error:
                type_err = "NaN"
            else:
                msg_dtype = msg_dtype if msg_dtype is not None else X.dtype
                type_err = f"infinity or a value too large for {msg_dtype!r}"
            padded_input_name = input_name + " " if input_name else ""
            msg_err = f"Input {padded_input_name}contains {type_err}."
            if estimator_name and input_name == "X" and has_nan_error:
                # Improve the error message on how to handle missing values in
                # scikit-learn.
                msg_err += (
                    f"\n{estimator_name} does not accept missing values"
                    " encoded as NaN natively. For supervised learning, you might want"
                    " to consider sklearn.ensemble.HistGradientBoostingClassifier and"
                    " Regressor which accept missing values encoded as NaNs natively."
                    " Alternatively, it is possible to preprocess the data, for"
                    " instance by using an imputer transformer in a pipeline or drop"
                    " samples with missing values. See"
                    " https://scikit-learn.org/stable/modules/impute.html"
                    " You can find a list of all estimators that handle NaN values"
                    " at the following page:"
                    " https://scikit-learn.org/stable/modules/impute.html"
                    "#estimators-that-handle-nan-values"
                )
>           raise ValueError(msg_err)
E           ValueError: Input contains NaN.

/Users/awitmer/neat_ml_venv/lib/python3.11/site-packages/sklearn/utils/validation.py:169: ValueError
```

</details>

This error shows that calling the `lime.explain_instance` method results in an error in the `scikit-learn`, `r2_score` function. I probed the `sklearn.base.score` functionality with a local installation of  `scikit-learn` and ran the failing test using both `scipy==1.16.3` and `1.17.0` to see the values of `y_pred` that are being passed to `return r2_score(y, y_pred, sample_weight=sample_weight)`:

with `scipy==1.16.3` the values are:

```
array([0.84760197, 0.84760197, 0.84760197, ..., 0.84760197, 0.84760197, 0.84760197])
```

whereas with `scipy==1.17.0` the values are:

```
array([nan, nan, nan, ..., nan, nan, nan])
```

This, in turn, is caused by the prediction of the `Ridge` classifier used by `lime`. These outputs are similar for multiple versions of `scikit-learn`, which leads me to believe that the problem is indeed with `scipy`, not `scikit-learn`. 

I grepped through the `lime` repo to see where it uses `scipy` functions and noticed that it does check for sparsity of the data with `scipy.sparse.issparce` in several places. Based on the release notes for `scipy 1.17.0`, some of the functionality for `scipy.sparse` has changed, however, none of the calls to check for sparsity return `True` for the input data. Other `scipy` functions used by `lime` include the `scipy.stats.distributions.norm` function (which is not called by `lime` for this test) as well as the `scipy.stats.truncnorm.rsv` function. There are some discrepancies when looking at the `ret` values of `lime` `get_undescritized_values` (which uses `truncnorm.rsv`) between `scipy` versions. These are related to extremely small floating point values (e.g. `1.02005557e-11` for `scipy==1.17.0` vs. `6.92387151e-12` for `scipy==1.16.3`) but I do not have a root-cause for why that would be causing the `nan` value predictions. 