### PR TITLE
DOC: update `README.md` to use FCI compliant O#

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LDRD_NEAT_ML (LANL copyright assertion ID: O# (O4909))
+# LDRD_NEAT_ML (LANL copyright assertion ID: O# (O4975))
 
 ## Installing the project
 


### PR DESCRIPTION
In line with issue #7 item 1: 

>  Reference this O# (O4975) in the repository README file so that copyright assertion can be confirmed.

* Update  O#: O4975 for FCI compliance.