### PR TITLE
DOC: modify license file to display license name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This program is Open-Source under the BSD-3 License.
+BSD 3-Clause License.
  
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:


### PR DESCRIPTION
closes #7

Modifies the `LICENSE` file to automatically display the correct license name in the repo by explicitly stating the name at the top of the file.