### PR TITLE
BUG: fix contour plotting for bubblesam detection

### DIFF
--- a/neat_ml/bubblesam/bubblesam.py
+++ b/neat_ml/bubblesam/bubblesam.py
@@ -274,9 +274,13 @@ def bubblesam_detection(
     # save filtered dataframe as parquet file
     # convert ``contour`` column to list to save as parquet
     save_filtered_df = filtered_df.copy()
-    save_filtered_df["contour"] = save_filtered_df["contour"].apply(list)
+    save_filtered_df["bbox"] = save_filtered_df["bbox"].apply(list)
+    save_filtered_df["contour"] = save_filtered_df["contour"].apply(
+        lambda x: [arr.tolist() if isinstance(arr, np.ndarray) else arr for arr in x]
+    )
     save_filtered_df.to_parquet(
         output_dir / f'{image_basename}_masks_filtered.parquet.gzip',
+        engine="fastparquet",
         compression="gzip",
     )
 

--- a/neat_ml/bubblesam/bubblesam.py
+++ b/neat_ml/bubblesam/bubblesam.py
@@ -277,6 +277,7 @@ def bubblesam_detection(
     save_filtered_df["contour"] = save_filtered_df["contour"].apply(list)
     save_filtered_df.to_parquet(
         output_dir / f'{image_basename}_masks_filtered.parquet.gzip',
+        compression="gzip",
     )
 
     if debug:

--- a/neat_ml/bubblesam/bubblesam.py
+++ b/neat_ml/bubblesam/bubblesam.py
@@ -272,7 +272,7 @@ def bubblesam_detection(
     )
    
     # save filtered dataframe as parquet file
-    # convert ``contour`` column to list to save as parquet
+    # convert ``contour`` and ``bbox`` columns to list to save as parquet
     save_filtered_df = filtered_df.copy()
     save_filtered_df["bbox"] = save_filtered_df["bbox"].apply(list)
     save_filtered_df["contour"] = save_filtered_df["contour"].apply(

--- a/neat_ml/bubblesam/bubblesam.py
+++ b/neat_ml/bubblesam/bubblesam.py
@@ -131,7 +131,9 @@ def analyze_and_filter_masks(
         if len(props_list) == 0:
             continue
 
-        rp = props_list[0]
+        # take the region properties from the segmentation map with the greatest area
+        rp_areas = [x.area for x in props_list]
+        rp = props_list[np.argmax(rp_areas)]
         area = rp.area
         perimeter = rp.perimeter
         if perimeter == 0:
@@ -141,19 +143,18 @@ def analyze_and_filter_masks(
         major_axis = rp.major_axis_length
         minor_axis = rp.minor_axis_length
         h, w = seg.shape[:2]
-        # Using a small margin (2 pixels) to be safe
+        # Using a small margin (2 pixels) to be safe,
+        # filter any segmentations with bounding boxes close to the size of the image
+        # because SAM-2 can sometimes detect the image background itself.
+        bbox_area = np.prod(rp.bbox[2:])
         max_allowed_area = (h - 2) * (w - 2)
-        if area >= area_threshold and circ >= circularity_threshold:
+        if (area >= area_threshold and circ >= circularity_threshold
+            and bbox_area < max_allowed_area):
             binary_mask = seg.astype('uint8') * 255
             contours, _ = cv2.findContours(binary_mask, cv2.RETR_LIST, cv2.CHAIN_APPROX_NONE)
-            # reshape contours for plotting and remove any contours
-            # close to the size of the image because cv2.findContours
-            # can sometimes detect the image edge itself.
-            all_contours = [
-                c.reshape(-1, 2)[:, ::-1]
-                for c in contours
-                if cv2.contourArea(c) < max_allowed_area
-            ]
+            # keep only the largest contour in each segmentation area
+            # and reshape for plotting
+            max_contour = max(contours, key=cv2.contourArea).squeeze()
             radius = np.sqrt(area / np.pi)
             euler_number = rp.euler_number
             # output of cucim ``rp`` stores values as objects
@@ -164,7 +165,7 @@ def analyze_and_filter_masks(
                 euler_number = euler_number.item()
             mask_info = {              
                 'bbox': rp.bbox,
-                'contour': all_contours,
+                'contour': max_contour,
                 'major_axis': major_axis,
                 'minor_axis': minor_axis,
                 'area': area,
@@ -202,7 +203,7 @@ def plot_filtered_masks(
     for idx, row in masks_summary_df.iterrows():
         contour = row['contour']
         bbox = row['bbox']
-        ax.plot(contour[0][:, 1], contour[0][:, 0], linewidth=1, color='blue')
+        ax.plot(contour[:, 0], contour[:, 1], linewidth=1, color='blue')
         min_row, min_col, max_row, max_col = bbox
         rect = Rectangle(
             (min_col, min_row),
@@ -271,16 +272,11 @@ def bubblesam_detection(
     )
    
     # save filtered dataframe as parquet file
-    # convert ``contours`` and ``bbox`` columns to list to save as parquet
+    # convert ``contour`` column to list to save as parquet
     save_filtered_df = filtered_df.copy()
-    save_filtered_df["bbox"] = save_filtered_df["bbox"].apply(list)
-    save_filtered_df["contour"] = save_filtered_df["contour"].apply(
-        lambda x: [arr.tolist() if isinstance(arr, np.ndarray) else arr for arr in x]
-    )
+    save_filtered_df["contour"] = save_filtered_df["contour"].apply(list)
     save_filtered_df.to_parquet(
         output_dir / f'{image_basename}_masks_filtered.parquet.gzip',
-        engine="fastparquet",
-        compression="gzip",
     )
 
     if debug:

--- a/neat_ml/bubblesam/bubblesam.py
+++ b/neat_ml/bubblesam/bubblesam.py
@@ -146,7 +146,7 @@ def analyze_and_filter_masks(
         # Using a small margin (2 pixels) to be safe,
         # filter any segmentations with bounding boxes close to the size of the image
         # because SAM-2 can sometimes detect the image background itself.
-        bbox_area = np.prod(rp.bbox[2:])
+        bbox_area = (rp.bbox[2] - rp.bbox[0]) * (rp.bbox[3] - rp.bbox[1])
         max_allowed_area = (h - 2) * (w - 2)
         if (area >= area_threshold and circ >= circularity_threshold
             and bbox_area < max_allowed_area):
@@ -154,7 +154,7 @@ def analyze_and_filter_masks(
             contours, _ = cv2.findContours(binary_mask, cv2.RETR_LIST, cv2.CHAIN_APPROX_NONE)
             # keep only the largest contour in each segmentation area
             # and reshape for plotting
-            max_contour = max(contours, key=cv2.contourArea).squeeze()
+            max_contour = max(contours, key=cv2.contourArea).squeeze(axis=1)
             radius = np.sqrt(area / np.pi)
             euler_number = rp.euler_number
             # output of cucim ``rp`` stores values as objects

--- a/neat_ml/tests/test_bubblesam.py
+++ b/neat_ml/tests/test_bubblesam.py
@@ -156,6 +156,7 @@ def test_bubblesam_detection_generates_pngs(
     )
     saved_df = pd.read_parquet(
         out_dir / "circles_masks_filtered.parquet.gzip",
+        engine="fastparquet",
     )
     saved_df["bbox"] = saved_df["bbox"].apply(tuple)
     saved_df['contour'] = saved_df['contour'].apply(
@@ -318,17 +319,28 @@ def test_run_bubblesam_model_cfg_error():
     with pytest.raises(ValueError, match="Must provide model configuration"):
         run_bubblesam(pd.DataFrame(), Path("output"), detection_cfg={})
 
-def test_bubblesam_contours():
+@pytest.mark.parametrize("seg_params, exp_bbox",
+    [  
+        # a test case where the segmentation contains two disjoint areas
+        ([[50, 60], [40, 45]], (50, 50, 60, 60)),
+        # a test case where the segmentation contains a region that touches
+        # the image boundary at the bottom right corner
+        ([[90, 100]], (90, 90, 100, 100)),
+    ]
+)
+def test_bubblesam_contours(seg_params, exp_bbox):
     """
     test that running `analyze_and_filter_masks` generates a dataframe with
     only a single contour per detection and without background areas
     """
     # create two segmentation maps, one that takes up the whole image (background)
-    # and one that has two segmented areas (one smaller than the other)
+    # and one containing the segmentation map generated using the test case parameters
     seg = np.ones((100, 100)).astype(bool)
     seg2 = np.zeros((100, 100)).astype(bool)
-    seg2[50:60, 50:60] = True
-    seg2[40:45, 40:45] = True
+    for seg_param in seg_params:
+        start = seg_param[0]
+        end = seg_param[1]
+        seg2[start:end, start:end] = True
     input_df = pd.DataFrame({"segmentation": [seg, seg2]})
     # call `analyze_and_filter_masks` to return filtered dataframe
     # (the circularity of a perfect square is ~0.8, so lower the
@@ -336,6 +348,6 @@ def test_bubblesam_contours():
     # out by the bounding box area)
     df = analyze_and_filter_masks(input_df, 25, 0.7, device="cpu")
     # assert that there is only a single dataframe row after filtration
-    # corresponding to the larger of the two segmented areas from `seg2`
-    assert df.bbox.item() == (50, 50, 60, 60)
+    # corresponding to the appropriate segmentation map to keep from `seg2`
+    assert df.bbox.item() == exp_bbox
     assert df.contour.item().shape == (36, 2)

--- a/neat_ml/tests/test_bubblesam.py
+++ b/neat_ml/tests/test_bubblesam.py
@@ -156,7 +156,6 @@ def test_bubblesam_detection_generates_pngs(
     )
     saved_df = pd.read_parquet(
         out_dir / "circles_masks_filtered.parquet.gzip",
-        engine="fastparquet",
     )
     saved_df["bbox"] = saved_df["bbox"].apply(tuple)
     saved_df['contour'] = saved_df['contour'].apply(
@@ -318,3 +317,25 @@ def test_run_bubblesam_model_cfg_error():
     """
     with pytest.raises(ValueError, match="Must provide model configuration"):
         run_bubblesam(pd.DataFrame(), Path("output"), detection_cfg={})
+
+def test_bubblesam_contours():
+    """
+    test that running `analyze_and_filter_masks` generates a dataframe with
+    only a single contour per detection and without background areas
+    """
+    # create two segmentation maps, one that takes up the whole image (background)
+    # and one that has two segmented areas (one smaller than the other)
+    seg = np.ones((100, 100)).astype(bool)
+    seg2 = np.zeros((100, 100)).astype(bool)
+    seg2[50:60, 50:60] = True
+    seg2[40:45, 40:45] = True
+    input_df = pd.DataFrame({"segmentation": [seg, seg2]})
+    # call `analyze_and_filter_masks` to return filtered dataframe
+    # (the circularity of a perfect square is ~0.8, so lower the
+    # circularity threshold so that the background only gets filtered
+    # out by the bounding box area)
+    df = analyze_and_filter_masks(input_df, 25, 0.7, device="cpu")
+    # assert that there is only a single dataframe row after filtration
+    # corresponding to the larger of the two segmented areas from `seg2`
+    assert df.bbox.item() == (50, 50, 60, 60)
+    assert df.contour.item().shape == (36, 2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     'pyyaml',
     'pooch',
     'pyarrow',
+    'fastparquet',
     'torch',
     'torchvision',
     'huggingface_hub',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     'pyyaml',
     'pooch',
     'pyarrow',
-    'fastparquet',
     'torch',
     'torchvision',
     'huggingface_hub',


### PR DESCRIPTION
Based on previous discussions during manuscript preparation, there is a bug in the main workflow that prevents the contours of segmented areas from being plotted correctly when performing bubble detection using SAM-2. This is because the SAM-2 segmentation maps sometimes contain multiple disjoint areas for a single detected bubble, and the workflow only plots the contour for the smaller of the two areas, resulting in what looks like an empty bounding box for some detected regions. This can be observed by performing detection on the image with "irregular shapes" that is included in the manuscript:

[offset 25_left_A6_O_Ph_Raw_541a67b3-783f-485a-9249-e7dc06b309fe-2.tiff](https://github.com/user-attachments/files/28482375/offset.25_left_A6_O_Ph_Raw_541a67b3-783f-485a-9249-e7dc06b309fe-2.tiff)

The output of running the workflow using the following incantation and `yaml` file on main demonstrates the bug:

`python run_workflow.py --config test_contour_plotting.yaml --steps detect`

<details><summary>test_contour_plotting.yaml</summary>

```yaml
roots:
  work: plot_contours

datasets:
  - id: Test
    method: BubbleSAM
    class: ''
    time_label: ''

    detection:
      img_dir: "offset 25_left_A6_O_Ph_Raw_541a67b3-783f-485a-9249-e7dc06b309fe-2.tiff"
      debug: True
      area_threshold: 1000
      circularity_threshold: 0.0
      model_cfg:
        mask_settings:
          points_per_side: 16
          points_per_batch: 64
          pred_iou_thresh: 0.80
          stability_score_thresh: 0.80
          stability_score_offset: 0.10
          crop_n_layers: 0
          box_nms_thresh: 0.10
          crop_n_points_downscale_factor: 1
          min_mask_region_area: 5
          use_m2m: True
        checkpoint_path: "facebook/sam2.1-hiera-tiny"
        device: "gpu"
```

</details>

<details><summary>Output on main (incorrect contours)</summary>

<img width="1386" height="1168" alt="image" src="https://github.com/user-attachments/assets/3f100877-58a4-4186-bed5-fc80ee27b2db" />

</details>

You can see that within some of the "emtpy" bounding boxes, there are very small blue contours being drawn for those smaller disjoint areas. There is also still a bounding box around the perimeter of the image because the logic used to filter out the segmented background region was using the contour area (which can still be less than `max_allowed_area`) instead of the bounding box area, which is generally closer to the shape of the image itself. 

The output of running the workflow using the same `yaml` file on this branch shows the correct contours plotted on the input image:

<details><summary>Output on this branch (correct contours)</summary>

<img width="1386" height="1168" alt="image" src="https://github.com/user-attachments/assets/3f386708-fe0e-407a-84c8-5ec716dc3ca3" />

</details>

The image now contains all the correct contours for each bounding box in the image, and does not contain the bounding box for the background area. There is also a new bounding box/contour for a detected region in the top left corner of the image that was previously filtered out because the function `analyze_and_filter_masks` was taking only the first `rp` object from each call of the function `sklearn.measure.regionprops`, instead of the largest of the multiple regions within a segmentation map.

This PR also allows for the simplification of downstream data structure handling by removing the jagged arrays storing "contour" information in the output dataframe from bubblesam detection ~~and includes changes such as the removal of the `fastparquet` engine for saving the dataframe as a parquet~~. This will also simplify the logic used in subsequent PR's for loading the saved dataframes, as noted in i.e. https://github.com/lanl/ldrd_neat_ml/pull/4#discussion_r3299125160.

_AI Disclosure: AI was not used in the original commits to this PR; Explicitly suggested fixes from greptile reviewer were used in subsequent commits._
