### PR TITLE
ENH: modify centroid and bbox object handling for opencv bubble detection

### DIFF
--- a/neat_ml/opencv/detection.py
+++ b/neat_ml/opencv/detection.py
@@ -69,7 +69,6 @@ def _detect_single_image(
 
     bubble_data = pd.DataFrame(index=range(len(keypoints)),
         columns=["bubble_number", "center_x", "center_y", "radius", "area", "bbox"]).fillna(np.nan)
-    bubble_data[['bbox']] = bubble_data[['bbox']].astype('object')
     for idx, kp in enumerate(keypoints):
         cx, cy = kp.pt
         r = kp.size / 2.0

--- a/neat_ml/opencv/detection.py
+++ b/neat_ml/opencv/detection.py
@@ -40,7 +40,10 @@ def _detect_single_image(
             - 'center_y' (float)
             - 'radius' (float)
             - 'area' (float)
-            - 'bbox' (tuple[int, int, int, int])
+            - 'bbox_xmin' (float)
+            - 'bbox_ymin' (float)
+            - 'bbox_xmax' (float)
+            - 'bbox_ymax' (float)
     """
     image = cv2.imread(img_path, cv2.IMREAD_GRAYSCALE)  # type: ignore[call-overload]
     if image is None:

--- a/neat_ml/opencv/detection.py
+++ b/neat_ml/opencv/detection.py
@@ -68,18 +68,31 @@ def _detect_single_image(
     keypoints = detector.detect(image)
 
     bubble_data = pd.DataFrame(index=range(len(keypoints)),
-        columns=["bubble_number", "center_x", "center_y", "radius", "area", "bbox"]).fillna(np.nan)
+        columns=[
+            "bubble_number",
+            "center_x",
+            "center_y",
+            "radius",
+            "area",
+            "bbox_xmin",
+            "bbox_ymin",
+            "bbox_xmax",
+            "bbox_ymax",
+        ]
+    )
     for idx, kp in enumerate(keypoints):
         cx, cy = kp.pt
         r = kp.size / 2.0
-        bbox = (cx - r, cy - r, cx + r, cy + r)
         bubble_data_row = {
             "bubble_number": idx + 1,
             "center_x": cx,
             "center_y": cy,
             "radius": r,
             "area": np.pi * r**2,
-            "bbox": bbox,
+            "bbox_xmin": cx - r,
+            "bbox_ymin": cy - r,
+            "bbox_xmax": cx + r,
+            "bbox_ymax": cy + r,
         }
         bubble_data.loc[idx] = pd.Series(bubble_data_row)
 
@@ -115,8 +128,9 @@ def _save_debug_overlay(
     overlay = image_rgb.copy()
 
     for index, bubble in bubble_data.iterrows():
-        bbox = bubble["bbox"]
-        x_min, y_min, x_max, y_max = map(int, bbox)
+        x_min, y_min, x_max, y_max = map(
+            int, bubble[["bbox_xmin", "bbox_ymin", "bbox_xmax", "bbox_ymax"]]
+        )
         cv2.rectangle(overlay, (x_min, y_min), (x_max, y_max), (0, 255, 0), 2)
 
     fig, ax = plt.subplots(1, 2, figsize=(12, 8))

--- a/neat_ml/opencv/detection.py
+++ b/neat_ml/opencv/detection.py
@@ -36,7 +36,8 @@ def _detect_single_image(
         bubble_data : pd.DataFrame
             DataFrame with one row per detected blob, each containing:
             - 'bubble_number' (int)
-            - 'center' (tuple[float, float])
+            - 'center_x' (float)
+            - 'center_y' (float)
             - 'radius' (float)
             - 'area' (float)
             - 'bbox' (tuple[int, int, int, int])
@@ -67,15 +68,16 @@ def _detect_single_image(
     keypoints = detector.detect(image)
 
     bubble_data = pd.DataFrame(index=range(len(keypoints)),
-        columns=["bubble_number", "center", "radius", "area", "bbox"]).fillna(np.nan)
-    bubble_data[['center', 'bbox']] = bubble_data[['center', 'bbox']].astype('object')
+        columns=["bubble_number", "center_x", "center_y", "radius", "area", "bbox"]).fillna(np.nan)
+    bubble_data[['bbox']] = bubble_data[['bbox']].astype('object')
     for idx, kp in enumerate(keypoints):
         cx, cy = kp.pt
         r = kp.size / 2.0
         bbox = (cx - r, cy - r, cx + r, cy + r)
         bubble_data_row = {
             "bubble_number": idx + 1,
-            "center": (cx, cy),
+            "center_x": cx,
+            "center_y": cy,
             "radius": r,
             "area": np.pi * r**2,
             "bbox": bbox,

--- a/neat_ml/tests/test_detection.py
+++ b/neat_ml/tests/test_detection.py
@@ -72,8 +72,18 @@ def test_detect_single_image_processed(tmp_path: Path, reference_images: tuple):
     num_blobs, median_r, bubble_data = _detect_single_image(img_path)
     assert num_blobs == 1735
     assert_allclose(median_r, 3.623063564300537)
-    assert bubble_data.shape == (1735, 6)
-    exp_cols = ["bubble_number", "center_x", "center_y", "radius", "area", "bbox"]
+    assert bubble_data.shape == (1735, 9)
+    exp_cols = [
+        "bubble_number",
+        "center_x",
+        "center_y",
+        "radius",
+        "area",
+        "bbox_xmin",
+        "bbox_ymin",
+        "bbox_xmax",
+        "bbox_ymax",
+    ]
     assert list(bubble_data.columns) == exp_cols 
 
 

--- a/neat_ml/tests/test_detection.py
+++ b/neat_ml/tests/test_detection.py
@@ -73,6 +73,8 @@ def test_detect_single_image_processed(tmp_path: Path, reference_images: tuple):
     assert num_blobs == 1735
     assert_allclose(median_r, 3.623063564300537)
     assert bubble_data.shape == (1735, 6)
+    exp_cols = ["bubble_number", "center_x", "center_y", "radius", "area", "bbox"]
+    assert list(bubble_data.columns) == exp_cols 
 
 
 def test_run_opencv_out_dir_error():

--- a/neat_ml/tests/test_detection.py
+++ b/neat_ml/tests/test_detection.py
@@ -72,7 +72,7 @@ def test_detect_single_image_processed(tmp_path: Path, reference_images: tuple):
     num_blobs, median_r, bubble_data = _detect_single_image(img_path)
     assert num_blobs == 1735
     assert_allclose(median_r, 3.623063564300537)
-    assert bubble_data.shape == (1735, 5)
+    assert bubble_data.shape == (1735, 6)
 
 
 def test_run_opencv_out_dir_error():


### PR DESCRIPTION
In line with https://github.com/lanl/ldrd_neat_ml/pull/4#discussion_r3299405723, simplify centroid and bounding box coordinate storage for the `OpenCV` detection module by storing all coordinates in a separate columns, as opposed to storing them as tuple objects in single columns. 

_AI Disclosure: AI was not used for writing the intial commits used in this PR; Explicit suggestions from the greptile AI were used in subsequent commits._