### PR TITLE
CI: cache microsoft fonts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,19 @@ jobs:
         echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
         sudo apt-get update
         sudo apt-get install -y ttf-mscorefonts-installer || true
-        mkdir -p ~/.cache/msttcorefonts/
-        cp /usr/share/fonts/truetype/msttcorefonts/*.ttf ~/.cache/msttcorefonts/
+        # before making the user storage directory, check if the font(s) we need
+        # (i.e. `Arial.ttf` and `Arial_Bold.ttf`) exist/were successfully downloaded
+        # to the root directory to avoid loading an empty directory on a successful
+        # ``cache-hit``
+        if [[ ! -f "/usr/share/fonts/truetype/msttcorefonts/Arial.ttf" || \
+            ! -f "/usr/share/fonts/truetype/msttcorefonts/Arial_Bold.ttf" ]]; then
+            echo "Fonts not downloaded successfully."
+            exit 1
+        else
+            echo "Fonts downloaded successfully. Caching fonts..."
+            mkdir -p ~/.cache/msttcorefonts/
+            cp /usr/share/fonts/truetype/msttcorefonts/*.ttf ~/.cache/msttcorefonts/
+        fi
     - name: install fonts from cache
       if: runner.os == 'Linux' && steps.cache-fonts.outputs.cache-hit == 'true'
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     - name: cache fonts
       id: cache-fonts
       if: runner.os == 'Linux'
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5
       with:
         path: ~/.cache/msttcorefonts/
         key: ${{ runner.os }}-msttcorefonts-v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       if: runner.os == 'Linux'
       uses: actions/cache@v5
       with:
-        path: /usr/share/fonts/truetype/msttcorefonts/
+        path: ~/.cache/msttcorefonts/
         key: ${{ runner.os }}-msttcorefonts-v1
     - name: install fonts
       if: runner.os == 'Linux' && steps.cache-fonts.outputs.cache-hit != 'true'
@@ -38,6 +38,13 @@ jobs:
         echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
         sudo apt-get update
         sudo apt-get install -y ttf-mscorefonts-installer || true
+        mkdir -p ~/.cache/msttcorefonts/
+        cp /usr/share/fonts/truetype/msttcorefonts/*.ttf ~/.cache/msttcorefonts/
+    - name: install fonts from cache
+      if: runner.os == 'Linux' && steps.cache-fonts.outputs.cache-hit == 'true'
+      run: |
+        sudo mkdir -p /usr/share/fonts/truetype/msttcorefonts/
+        sudo cp ~/.cache/msttcorefonts/*.ttf /usr/share/fonts/truetype/msttcorefonts/
     - name: refresh font cache
       if: runner.os == 'Linux'
       run: sudo fc-cache -f -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,22 @@ jobs:
         python -m pip install -v ".[dev]"
         mypy neat_ml
         ruff check neat_ml
-    - name: install fonts
+    - name: cache fonts
+      id: cache-fonts
       if: runner.os == 'Linux'
+      uses: actions/cache@v5
+      with:
+        path: /usr/share/fonts/truetype/msttcorefonts/
+        key: ${{ runner.os }}-msttcorefonts-v1
+    - name: install fonts
+      if: runner.os == 'Linux' && steps.cache-fonts.outputs.cache-hit != 'true'
       run: |
         echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
         sudo apt-get update
         sudo apt-get install -y ttf-mscorefonts-installer || true
-        sudo fc-cache -f -v
+    - name: refresh font cache
+      if: runner.os == 'Linux'
+      run: sudo fc-cache -f -v
     - name: test
       run: |
         cd /tmp && python -m pytest --pyargs neat_ml --cov=neat_ml --cov-report=term-missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     - name: cache fonts
       id: cache-fonts
       if: runner.os == 'Linux'
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
       with:
         path: ~/.cache/msttcorefonts/
         key: ${{ runner.os }}-msttcorefonts-v1


### PR DESCRIPTION
* Fixes #22
* add `GitHub` caching for font installation to reduce intermittent errors in downloading fonts that cause CI failure because of absence of Arial type font for plot generation

_AI Disclosure: AI was used to help write the changes in this PR, specifically Claude prototyped the code for me based on the prompt to cache the downloaded fonts and then helped revised the code to avoid the bug that greptile found. I read docs such as https://github.com/marketplace/actions/cache and watched this video (https://www.youtube.com/watch?v=BDQivAobxKA) to better understand how the github actions performs caching_