### PR TITLE
BLD: pin matplotlib to < 3.11.0

### DIFF
--- a/neat_ml/__init__.py
+++ b/neat_ml/__init__.py
@@ -1,0 +1,6 @@
+import matplotlib
+from packaging.version import Version
+
+
+if not Version(matplotlib.__version__) < Version('3.11.0'):
+    raise ImportError("Workflow currently only supports `matplotlib<3.11.0`")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "neat_ml"
 version = "0.0.1.dev0"
 dependencies = [
     'numpy>=1.26.3,<=2.1.3',
-    'matplotlib',
+    'matplotlib<3.11.0',  # backwards incompatibility for image comparison tests (see issue #36)
     'xgboost',
     'pandas',
     'scikit-learn',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
     'torch',
     'torchvision',
     'huggingface_hub',
-    'sam-2 @ git+https://github.com/facebookresearch/sam2@2b90b9f5ceec907a1c18123530e92e794ad901a4'
+    'sam-2 @ git+https://github.com/facebookresearch/sam2@2b90b9f5ceec907a1c18123530e92e794ad901a4',
+    'packaging',
 ]
 [project.optional-dependencies]
 dev = ['mypy',


### PR DESCRIPTION
As mentioned in issue #36, the newest release of `matplotlib` (3.11.0) includes changes to text and font handling that break tests that rely on pixel level image comparisons (https://matplotlib.org/stable/release/prev_whats_new/whats_new_3.11.0#fonts-and-text). This PR pins `matplotlib` to versions below `3.11.0` to avoid implementing suggested work-arounds from the `matplotlib` release notes including:

1. Regenerating all test images and removing support for versions lower than 3.11.0. I don't think we want to exclude all older versions of `matplotlib` in our workflow.
2. Removing text from plots or using placeholders. We specifically check font style with image comparison.
3. Loosening image comparison tolerances. We are concerned with pixel level changes that may be missed by loosening tolerances, and we have already loosened tolerances to account for sub-pixel level inconsistencies between testing platforms. 
4. Changing the image comparison algorithm used for testing. "Perpetual hashing" was mentioned as one such option, but would require substantial refactoring of the current testing architecture.

_AI Disclosure: No AI tools were used in generating original commit to this PR. Claude was used to check what was common practice for implementing dependency version checks in open source packages, and suggestions were cross-referenced with widely used open source packages such as `pandas`_