### PR TITLE
MAINT: remove `fastparquet` compression for bubblesam parquet

### DIFF
--- a/neat_ml/bubblesam/bubblesam.py
+++ b/neat_ml/bubblesam/bubblesam.py
@@ -272,15 +272,12 @@ def bubblesam_detection(
     )
    
     # save filtered dataframe as parquet file
-    # convert ``contour`` and ``bbox`` columns to list to save as parquet
+    # convert ``contour`` column to list to save as parquet
+    # because PyArrow cannot save 2-d arrays 
     save_filtered_df = filtered_df.copy()
-    save_filtered_df["bbox"] = save_filtered_df["bbox"].apply(list)
-    save_filtered_df["contour"] = save_filtered_df["contour"].apply(
-        lambda x: [arr.tolist() if isinstance(arr, np.ndarray) else arr for arr in x]
-    )
+    save_filtered_df["contour"] = save_filtered_df["contour"].apply(list)
     save_filtered_df.to_parquet(
         output_dir / f'{image_basename}_masks_filtered.parquet.gzip',
-        engine="fastparquet",
         compression="gzip",
     )
 

--- a/neat_ml/tests/test_bubblesam.py
+++ b/neat_ml/tests/test_bubblesam.py
@@ -156,12 +156,10 @@ def test_bubblesam_detection_generates_pngs(
     )
     saved_df = pd.read_parquet(
         out_dir / "circles_masks_filtered.parquet.gzip",
-        engine="fastparquet",
     )
-    saved_df["bbox"] = saved_df["bbox"].apply(tuple)
-    saved_df['contour'] = saved_df['contour'].apply(
-        lambda x: [np.array(arr, dtype='int32') for arr in x]
-    )
+    # because `contour` is saved as a list, ``read_parquet``
+    # loads it as a 1-d array, so need to reshape it back to 2-d
+    saved_df['contour'] = saved_df['contour'].apply(np.stack)
     assert_frame_equal(df, saved_df)
 
     actual_overlay  = out_dir / f"{stem}_with_mask.png"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     'pyyaml',
     'pooch',
     'pyarrow',
-    'fastparquet',
     'torch',
     'torchvision',
     'huggingface_hub',


### PR DESCRIPTION
In line with https://github.com/lanl/ldrd_neat_ml/pull/4#discussion_r3404334326, this PR simplifies `bubblesam` parquet saving/loading by removing the use of `fastparquet` engine, which requires `json` serializable formats for saving objects. This change will also simplify parquet loading in PR #5 by unifying the parquet engine to use `pyarrow`. ~~and remove the need for the `ast` module there.~~

_AI Disclosure: No AI was used in this PR_