### PR TITLE
DOC: add citation information to repo

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,6 +17,7 @@ authors:
   - given-names: Mihee
     family-names: Kim
     email: miheekim@lanl.gov
+# TODO: add `doi:` key after code release 
 repository-code: 'https://github.com/lanl/ldrd_neat_ml'
 license: BSD-3-Clause
 preferred-citation:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,47 @@
+cff-version: 1.2.0
+title: ldrd_neat_ml
+message: "If you use this software, please cite the article listed in preferred-citation."
+type: software
+authors:
+  - given-names: Nidhin
+    family-names: Thomas
+  - given-names: Adam
+    family-names: Witmer
+  - given-names: Hyung
+    family-names: Lee
+  - given-names: Cesar
+    family-names: Lopez
+  - given-names: Tyler
+    family-names: Reddy
+    email: treddy@lanl.gov
+  - given-names: Mihee
+    family-names: Kim
+    email: miheekim@lanl.gov
+repository-code: 'https://github.com/lanl/ldrd_neat_ml'
+license: BSD-3-Clause
+preferred-citation:
+  type: article
+  title: Machine Learning-Assisted Phase Diagram Determination in Aqueous Two-Phase Systems
+  authors:
+  - given-names: Nidhin
+    family-names: Thomas
+  - given-names: Adam
+    family-names: Witmer
+  - given-names: Hyung
+    family-names: Lee
+  - given-names: Cesar
+    family-names: Lopez
+  - given-names: Tyler
+    family-names: Reddy
+    email: treddy@lanl.gov
+  - given-names: Mihee
+    family-names: Kim
+    email: miheekim@lanl.gov
+  journal: Langmuir 
+  doi: 10.1021/acs.langmuir.6c00306
+  volume: 42
+  issue: 18
+  pages: 12658--12669
+  year: 2026
+  publisher:
+    name: ACS Publications

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     family-names: Thomas
   - given-names: Adam
     family-names: Witmer
-  - given-names: Hyung
+  - given-names: Hyung Kae
     family-names: Lee
   - given-names: Cesar
     family-names: Lopez
@@ -28,7 +28,7 @@ preferred-citation:
     family-names: Thomas
   - given-names: Adam
     family-names: Witmer
-  - given-names: Hyung
+  - given-names: Hyung Kae
     family-names: Lee
   - given-names: Cesar
     family-names: Lopez

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ manuscript:
 
 `python -m neat_ml.plot_manuscript_figures`
 
-### Citing this Project
+## Citing this Project
 
 If you use the contents of this repository as part of a project that results in publication,
 please cite the following associated manuscript (citation information is available in the

--- a/README.md
+++ b/README.md
@@ -187,3 +187,15 @@ the following command to generate the figures used in the
 manuscript: 
 
 `python -m neat_ml.plot_manuscript_figures`
+
+### Citing this Project
+
+If you use the contents of this repository as part of a project that results in publication,
+please cite the following associated manuscript (citation information is available in the
+repository "About" section under "Cite this repository"):
+
+```
+Thomas, N., Witmer, A., Lee, H. K., López, C. A., Reddy, T., & Kim, M. (2026). Machine
+Learning-Assisted Phase Diagram Determination in Aqueous Two-Phase Systems. Langmuir,
+42(18), 12658-12669.
+```


### PR DESCRIPTION
Closes #42 

Adds citation information to the repo in the form(s) of a `CITATION.cff` file and new section in the `README` file referencing the manuscript associated with this repository. The `CITATION` file was generated in a similar manner to that of https://github.com/lanl/ldrd_virus_work/pull/51, i.e. by using the automatic file generator (https://citation-file-format.github.io/cff-initializer-javascript/#/) as a template and adding in a section for `preferred-citation`. The changes were checked by pushing the branch to the `main` of my remote fork to check that the appropriate references are generated in the repo `About` section (outputs shown below):

**APA**

```
Thomas, N., Witmer, A., Lee, H., Lopez, C., Reddy, T., & Kim, M. (2026). Machine Learning-Assisted Phase Diagram Determination in Aqueous Two-Phase Systems. Langmuir, 42(18). https://doi.org/10.1021/acs.langmuir.6c00306
```

**bibtex**

```
@article{Thomas_Machine_Learning-Assisted_Phase_2026,
author = {Thomas, Nidhin and Witmer, Adam and Lee, Hyung and Lopez, Cesar and Reddy, Tyler and Kim, Mihee},
doi = {10.1021/acs.langmuir.6c00306},
journal = {Langmuir},
number = {18},
title = {{Machine Learning-Assisted Phase Diagram Determination in Aqueous Two-Phase Systems}},
volume = {42},
year = {2026}
}
```

_AI Disclaimer: no AI was used in the generation of this PR._