### PR TITLE
ENH: calculate bubblesam bbox coordinates before saving parquet

### DIFF
--- a/neat_ml/bubblesam/bubblesam.py
+++ b/neat_ml/bubblesam/bubblesam.py
@@ -163,8 +163,17 @@ def analyze_and_filter_masks(
                 radius = radius.item()
                 circ = circ.item()
                 euler_number = euler_number.item()
+            # ymin, xmin, ymax, xmax
+            min_row, min_col, max_row, max_col = rp.bbox
+            cx = (max_col + min_col) / 2
+            cy = (max_row + min_row) / 2
             mask_info = {              
-                'bbox': rp.bbox,
+                'bbox_xmax': max_col,
+                'bbox_xmin': min_col,
+                'bbox_ymax': max_row,
+                'bbox_ymin': min_row,
+                'center_x': cx,
+                'center_y': cy,
                 'contour': max_contour,
                 'major_axis': major_axis,
                 'minor_axis': minor_axis,
@@ -202,9 +211,11 @@ def plot_filtered_masks(
 
     for idx, row in masks_summary_df.iterrows():
         contour = row['contour']
-        bbox = row['bbox']
         ax.plot(contour[:, 0], contour[:, 1], linewidth=1, color='blue')
-        min_row, min_col, max_row, max_col = bbox
+        min_row = row["bbox_ymin"]
+        min_col = row["bbox_xmin"]
+        max_row = row["bbox_ymax"]
+        max_col = row["bbox_xmax"]
         rect = Rectangle(
             (min_col, min_row),
             max_col - min_col,

--- a/neat_ml/bubblesam/bubblesam.py
+++ b/neat_ml/bubblesam/bubblesam.py
@@ -114,7 +114,8 @@ def analyze_and_filter_masks(
     Returns
     -------
     df_filtered : pd.DataFrame
-        A filtered DataFrame with new columns (contour, bbox, major_axis, minor_axis, 
+        A filtered DataFrame with new columns (contour, bbox_xmax, bbox_xmin,
+        bbox_ymax, bbox_ymin, center_x, center_y, major_axis, minor_axis, 
         area, radius, circ, euler_number) but excluding 'segmentation'.
     """
     filtered_rows = []
@@ -202,7 +203,9 @@ def plot_filtered_masks(
     original_image : np.ndarray
         Original image array.
     masks_summary_df : pd.DataFrame
-        DataFrame containing the columns 'contour' and 'bbox' for each mask.
+        DataFrame containing the columns with 'contour' and bounding box
+        coordinates ('bbox_xmax', 'bbox_xmin', 'bbox_ymax', and
+        'bbox_ymin') for each mask.
     output_path : Path
         File path to save the resulting figure.
     """

--- a/neat_ml/tests/test_bubblesam.py
+++ b/neat_ml/tests/test_bubblesam.py
@@ -320,10 +320,10 @@ def test_run_bubblesam_model_cfg_error():
 @pytest.mark.parametrize("seg_params, exp_bbox",
     [  
         # a test case where the segmentation contains two disjoint areas
-        ([[50, 60], [40, 45]], (50, 50, 60, 60)),
+        ([[50, 60], [40, 45]], [50, 50, 60, 60]),
         # a test case where the segmentation contains a region that touches
         # the image boundary at the bottom right corner
-        ([[90, 100]], (90, 90, 100, 100)),
+        ([[90, 100]], [90, 90, 100, 100]),
     ]
 )
 def test_bubblesam_contours(seg_params, exp_bbox):
@@ -347,5 +347,10 @@ def test_bubblesam_contours(seg_params, exp_bbox):
     df = analyze_and_filter_masks(input_df, 25, 0.7, device="cpu")
     # assert that there is only a single dataframe row after filtration
     # corresponding to the appropriate segmentation map to keep from `seg2`
-    assert df.bbox.item() == exp_bbox
+    # and that the bounding box values contained in the row
+    # correspond to the expected segmentation map.
+    actual_bbox = [
+        df.bbox_ymin.item(), df.bbox_xmin.item(), df.bbox_ymax.item(), df.bbox_xmax.item()
+    ]
+    assert actual_bbox == exp_bbox
     assert df.contour.item().shape == (36, 2)

--- a/neat_ml/tests/test_bubblesam.py
+++ b/neat_ml/tests/test_bubblesam.py
@@ -320,10 +320,10 @@ def test_run_bubblesam_model_cfg_error():
 @pytest.mark.parametrize("seg_params, exp_bbox",
     [  
         # a test case where the segmentation contains two disjoint areas
-        ([[50, 60], [40, 45]], [50, 50, 60, 60]),
+        ([[50, 60], [40, 45]], (50, 50, 60, 60)),
         # a test case where the segmentation contains a region that touches
         # the image boundary at the bottom right corner
-        ([[90, 100]], [90, 90, 100, 100]),
+        ([[90, 100]], (90, 90, 100, 100)),
     ]
 )
 def test_bubblesam_contours(seg_params, exp_bbox):
@@ -349,8 +349,8 @@ def test_bubblesam_contours(seg_params, exp_bbox):
     # corresponding to the appropriate segmentation map to keep from `seg2`
     # and that the bounding box values contained in the row
     # correspond to the expected segmentation map.
-    actual_bbox = [
+    actual_bbox = (
         df.bbox_ymin.item(), df.bbox_xmin.item(), df.bbox_ymax.item(), df.bbox_xmax.item()
-    ]
+    )
     assert actual_bbox == exp_bbox
     assert df.contour.item().shape == (36, 2)


### PR DESCRIPTION
In line with the request to simplify parquet loading in PR #5 (https://github.com/lanl/ldrd_neat_ml/pull/4#discussion_r3404565457), this PR modifies the logic associated with BubbleSAM segmentation mask post-processing to separate bounding box coordinates into individual dataframe columns as well as calculate the centroid values directly before saving the dataframe as a parquet file. This change improves congruity of dataframe column names between `OpenCV` and `BubbleSAM` detection methods and will allow for simplification of dataframe loading in #5 such that these steps will not need to be performed after loading the `parquet` file.