### PR TITLE
CI: manually set device when running test suite in CI

### DIFF
--- a/neat_ml/bubblesam/SAM.py
+++ b/neat_ml/bubblesam/SAM.py
@@ -69,7 +69,7 @@ class SAMModel:
             system hardware.
         """
         # for GitHub CI: only use device="cpu" to avoid errors with macos `mps` backend (see issue #41)
-        if os.getenv("GITHUB_ACTIONS"):
+        if os.getenv("GITHUB_ACTIONS") == "true":
             self.device = "cpu"
         else:
             self.device = (

--- a/neat_ml/bubblesam/SAM.py
+++ b/neat_ml/bubblesam/SAM.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 import numpy as np
 import torch
 import logging
+import os
 
 from sam2.automatic_mask_generator import SAM2AutomaticMaskGenerator
 
@@ -67,11 +68,15 @@ class SAMModel:
             appropriate `SAM2` model backend as determined by user input and available
             system hardware.
         """
-        self.device = (
-            "cuda" if (torch.cuda.is_available() and device == "gpu")
-            else "mps" if (torch.backends.mps.is_available() and device == "gpu")
-            else "cpu"
-        )
+        # for GitHub CI: only use device="cpu" to avoid errors with macos `mps` backend (see issue #41)
+        if os.getenv("GITHUB_ACTIONS"):
+            self.device = "cpu"
+        else:
+            self.device = (
+                "cuda" if (torch.cuda.is_available() and device == "gpu")
+                else "mps" if (torch.backends.mps.is_available() and device == "gpu")
+                else "cpu"
+            )
         if device == "gpu":
             if torch.cuda.is_available():
                 torch.autocast(


### PR DESCRIPTION
In relation to the `CI` error described in issue #41, this PR provides a workaround for manually setting the `torch` device to "cpu" when running the test suite in the CI by checking for the presence of the unique `GITHUB_ACTIONS` default environment variable (https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables) during `SAM2` model initialization. This logic is used in other open-source projects, i.e. https://github.com/computational-cell-analytics/micro-sam/blob/d80f8b811bd9a5c0e2026734ff56fe15a53226c1/micro_sam/util.py#L185.

_AI Disclaimer: no AI was used in this PR._