### PR TITLE
MAINT, TYP: add mypy ignore for legacy code and remove numpy upper bound

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -30,3 +30,8 @@ ignore_missing_imports = True
 
 [mypy-cupy.*]
 ignore_missing_imports = True
+
+# ignore mypy errors associated with
+# unmaintained legacy code in `neat_ml.lib`
+[mypy-neat_ml.lib]
+ignore_errors = True

--- a/neat_ml/tests/test_bubblesam.py
+++ b/neat_ml/tests/test_bubblesam.py
@@ -218,7 +218,7 @@ def test_sam_internal_api(
     total_area = np.sum([x.get("area") for x in masks])
     assert len(masks) == 24
     assert total_area == 5091
-    assert_allclose(iou, 0.880697)
+    assert_allclose(iou, 0.880697)  # type: ignore[arg-type]
 
 @pytest.mark.parametrize("device",
     [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = ["setuptools>=68.2.2",
 name = "neat_ml"
 version = "0.0.1.dev0"
 dependencies = [
-    'numpy>=1.26.3,<=2.1.3',
+    'numpy>=1.26.3',
     'matplotlib<3.11.0',  # backwards incompatibility for image comparison tests (see issue #36)
     'xgboost',
     'pandas',


### PR DESCRIPTION
Closes #38 

Adds a block to `mypy.ini` to ignore errors associated with unmaintained legacy code (i.e. `neat_ml.lib`) and removes the `numpy` dependency upper bound that was imposed in https://lisdi-git.lanl.gov/ldrd_dr_neat/ldrd_neat_ml/-/merge_requests/49 due to `mypy` version incompatibility. 