### PR TITLE
MAINT: remove storage of bubblesam `contour` in output parquet

### DIFF
--- a/neat_ml/bubblesam/bubblesam.py
+++ b/neat_ml/bubblesam/bubblesam.py
@@ -286,10 +286,9 @@ def bubblesam_detection(
     )
    
     # save filtered dataframe as parquet file
-    # convert ``contour`` column to list to save as parquet
-    # because PyArrow cannot save 2-d arrays 
     save_filtered_df = filtered_df.copy()
-    save_filtered_df["contour"] = save_filtered_df["contour"].apply(list)
+    # drop the `contour` column which is not used in any downstream processes
+    save_filtered_df.drop(columns=["contour"], inplace=True)
     save_filtered_df.to_parquet(
         output_dir / f'{image_basename}_masks_filtered.parquet.gzip',
         compression="gzip",

--- a/neat_ml/bubblesam/bubblesam.py
+++ b/neat_ml/bubblesam/bubblesam.py
@@ -265,9 +265,9 @@ def bubblesam_detection(
 
     Returns
     -------
-    filtered_df : pd.DataFrame
+    save_filtered_df : pd.DataFrame
         A DataFrame containing properties of the masks (e.g., bubbles), 
-        including contour, bounding box, axes lengths, etc.
+        including bounding box, axes lengths, etc.
     """
     image_basename = image_path.stem
     image = cv2.imread(image_path)  # type: ignore[call-overload]
@@ -287,7 +287,8 @@ def bubblesam_detection(
    
     # save filtered dataframe as parquet file
     save_filtered_df = filtered_df.copy()
-    # drop the `contour` column which is not used in any downstream processes
+    # drop the `contour` column which is only used for `plot_filtered_masks`
+    # when `debug==True`, so we dont need to store it in the output dataframe.
     save_filtered_df.drop(columns=["contour"], inplace=True)
     save_filtered_df.to_parquet(
         output_dir / f'{image_basename}_masks_filtered.parquet.gzip',
@@ -316,7 +317,7 @@ def bubblesam_detection(
     elif (torch.backends.mps.is_available() and sam_model.device != "cpu"):
         torch.mps.empty_cache()
 
-    return filtered_df
+    return save_filtered_df
 
 def run_bubblesam(
     df_imgs: pd.DataFrame,

--- a/neat_ml/tests/test_bubblesam.py
+++ b/neat_ml/tests/test_bubblesam.py
@@ -154,12 +154,12 @@ def test_bubblesam_detection_generates_pngs(
         circularity_threshold=0.90,
         debug=True,
     )
+    # drop the contour column which is only used
+    # for plotting and not saved for any downstream processes
+    df.drop(columns=["contour"], inplace=True)
     saved_df = pd.read_parquet(
         out_dir / "circles_masks_filtered.parquet.gzip",
     )
-    # because `contour` is saved as a list, ``read_parquet``
-    # loads it as a 1-d array, so need to reshape it back to 2-d
-    saved_df['contour'] = saved_df['contour'].apply(np.stack)
     assert_frame_equal(df, saved_df)
 
     actual_overlay  = out_dir / f"{stem}_with_mask.png"

--- a/neat_ml/tests/test_bubblesam.py
+++ b/neat_ml/tests/test_bubblesam.py
@@ -154,9 +154,6 @@ def test_bubblesam_detection_generates_pngs(
         circularity_threshold=0.90,
         debug=True,
     )
-    # drop the contour column which is only used
-    # for plotting and not saved for any downstream processes
-    df.drop(columns=["contour"], inplace=True)
     saved_df = pd.read_parquet(
         out_dir / "circles_masks_filtered.parquet.gzip",
     )


### PR DESCRIPTION
closes #40 

This PR removes the dataframe column named `contour` from the dataframe that is saved as a `parquet` file after performing bubble detection with the `bubblesam` method. The column stores a 2D array that is used for plotting the detection overlay on the input image, but is not used in subsequent downstream processes (i.e. in the steps added in PRs #4 or #5) and therefore does not need to be stored in the output `parquet` file. This simplifies data structure handling by removing the need to convert the 2D array to a list before saving. 