### PR TITLE
MAINT: select old ruff rules 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,7 @@ dependencies = [
 ]
 [project.optional-dependencies]
 dev = ['mypy',
-       # ruff==0.16.0 introduces several default rules breaking linting
-       # see issue #49
-       'ruff<=0.15.22',
+       'ruff',
        'pandas-stubs',
        'pytest',
        'pytest-xdist',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 dev = ['mypy',
        # ruff==0.16.0 introduces several default rules breaking linting
        # see issue #49
-       'ruff<=0.15.2',
+       'ruff<=0.15.22',
        'pandas-stubs',
        'pytest',
        'pytest-xdist',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ dependencies = [
 ]
 [project.optional-dependencies]
 dev = ['mypy',
-       'ruff',
+       # ruff==0.16.0 introduces several default rules breaking linting
+       # see issue #49
+       'ruff<=0.15.2',
        'pandas-stubs',
        'pytest',
        'pytest-xdist',

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,2 +1,5 @@
 [lint]
+# ruff==0.16.0 introduces several default rules breaking linting
+# select "old" rules to maintain previous set (see issue #49)
+select = ["E4", "E7", "E9", "F"] 
 extend-select = ["B006", "B008", "UP032"]


### PR DESCRIPTION
Explicitly select "old" `ruff` rules in favor of adopting new `ruff` default rules as mentioned in https://astral.sh/blog/ruff-v0.16.0, i.e.:

```toml
[lint]
select = ["E4", "E7", "E9", "F"]
```

 Leaves the related issue (#49) open in case we want to implement these rules in the future.

_AI Disclosure Statement: No AI was used in the generation of this PR._