### PR TITLE
DOC: update README with new installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install the project, core dependencies,
 and optional dependencies by calling:
 
 ```
-python -m pip install -v ".[dev]" 
+python -m pip install -v . --group dev 
 ```
 
 ### Supported versions


### PR DESCRIPTION
* closes #55 

As mentioned in #55, using the previous installation instructions in `README` fails to install the optional `dev` dependencies without the existence of the `[optional-dependencies]` block in `pyproject.toml`. This PR modifies those instructions to use the suggestion from https://pip.pypa.io/en/stable/user_guide/#dependency-groups, i.e. `--group dev`, which properly installs all optional dependencies locally on `ARM M2 Macbook Pro`. 