### PR TITLE
MAINT, TST: remove "unknown" ds_id fallback from detection module

### DIFF
--- a/neat_ml/tests/test_workflow.py
+++ b/neat_ml/tests/test_workflow.py
@@ -10,18 +10,27 @@ from numpy.testing import assert_allclose
 import neat_ml.workflow.lib_workflow as wf
 
 
-def test_get_path_structure_builds_expected_paths(tmp_path: Path):
+@pytest.mark.parametrize("ds, exp_paths",
+    [
+        (
+            {"id": "DS1", "method": "OpenCV", "class": "pos", "time_label": "T01"},
+            "DS1/OpenCV/pos/T01"
+        ),
+        ({"method": "OpenCV"}, "OpenCV"),
+    ]
+)
+def test_get_path_structure_builds_expected_paths(tmp_path, ds, exp_paths):
     """
     get_path_structure: builds proc_dir and det_dir using ds_id/method/class/time_label.
     """
     roots = {"work": str(tmp_path)}
-    ds = {"id": "DS1", "method": "OpenCV", "class": "pos", "time_label": "T01"}
+    time_label = ds.get("time_label", "")
 
     paths = wf.get_path_structure(roots, ds)
 
-    base = tmp_path / "DS1" / "OpenCV" / "pos" / "T01"
-    assert paths["proc_dir"] == base / "T01_Processed_OpenCV"
-    assert paths["det_dir"] == base / "T01_Processed_OpenCV_With_Blob_Data"
+    base = tmp_path / exp_paths
+    assert paths["proc_dir"] == base / f"{time_label}_Processed_OpenCV"
+    assert paths["det_dir"] == base / f"{time_label}_Processed_OpenCV_With_Blob_Data"
 
 
 def test_get_path_structure_missing_work_raises_keyerror(tmp_path: Path):
@@ -138,10 +147,16 @@ def test_run_detection_skips_if_output_already_exists(
             {"proc_dir": "proc_dir", "det_dir": "det_dir"},
             {"image_filepath", "num_blobs_opencv", "median_radii_opencv"},
         ),
+        (    
+            {"method": "bubblesam", "detection": {}},
+            {"det_dir": "det_dir"},
+            {"image_filepath", "num_blobs_SAM", "median_radii_SAM"},
+        ),
     ]
 )
 def test_stage_detect_pipeline_runs(
     tmpdir,
+    caplog,
     mask_settings,
     reference_images: tuple,
     ds: dict,
@@ -152,8 +167,10 @@ def test_stage_detect_pipeline_runs(
     test that ``stage_detect`` runs successfully
     when provided the appropriate directories.
     """
+    caplog.set_level(logging.INFO) 
     raw_image = Path(reference_images[3])
     method = ds.get("method")
+    ds_id = ds.get("id", "")
     with tmpdir.as_cwd():
         proc_dir = Path("proc_dir")
         det_dir = Path("det_dir")
@@ -217,6 +234,8 @@ def test_stage_detect_pipeline_runs(
     assert det_dir_exp.is_absolute()
     assert df_out.shape == (1, 3)
     assert exp_columns.issubset(df_out.columns)
+    # check that detection uses the appropriate fallback for `ds_id`
+    assert f"Detecting blobs with {method} -> {ds_id} Output" in caplog.text
 
 
 def test_stage_detect_unknown_method_error(

--- a/neat_ml/workflow/lib_workflow.py
+++ b/neat_ml/workflow/lib_workflow.py
@@ -31,7 +31,7 @@ def get_path_structure(
         Paths keyed by step usage (proc_dir, det_dir).
     """
     paths = {}
-    ds_id = dataset_config.get("id", "unknown")
+    ds_id = dataset_config.get("id", "")
     method = dataset_config.get("method", "")
     class_label = dataset_config.get("class", "")
     time_label = dataset_config.get("time_label", "")
@@ -70,7 +70,7 @@ def run_detection(
     detection_cfg = dataset_config.get("detection", {})
     img_dir_str = detection_cfg.get("img_dir")
     debug = detection_cfg.get("debug", False)
-    ds_id = dataset_config.get("id", "unknown")
+    ds_id = dataset_config.get("id", "")
     method = dataset_config.get("method", "")
     # get method (``opencv`` or ``bubblesam``) and initialize
     # variables to guide function calls
@@ -110,7 +110,7 @@ def run_detection(
     else:
         proc_dir = img_dir
     
-    log.info(f"Detecting ({method}) for {ds_id} -> {det_dir}")
+    log.info(f"Detecting blobs with {method} -> {ds_id} Output folder: {det_dir}")
     # collect paths for preprocessed tiff image files, store in DataFrame
     # check if the path is a single file or a directory
     if proc_dir.is_file():


### PR DESCRIPTION
As noted in https://github.com/lanl/ldrd_neat_ml/pull/4#discussion_r3790340856, there is an inconsistency between the `ds_id` fallback values used by the `detection` and `analysis` modules. This PR removes the `"unknown"` fallback when the user fails to specify a `ds_id` in the input `yaml` file. It also adds regression test cases for appropriate fallbacks by checking the outputs of the related modules.